### PR TITLE
Skip serializing structs if default value

### DIFF
--- a/CodeGenerator/CodeGenerator/FieldSerializer.cs
+++ b/CodeGenerator/CodeGenerator/FieldSerializer.cs
@@ -303,7 +303,8 @@ namespace SilentOrbit.ProtocolBuffers
             if ( f.ProtoType.ProtoName == ProtoBuiltin.Double ) canDelta = true;
 
             // Don't change behavior of SerializeDelta() calls
-            bool canOptional = !hasPrevious;
+            // Don't skip enums when default values because their default may be awkward
+            bool canOptional = !hasPrevious && !(f.ProtoType is ProtoEnum);
 
             if (f.Rule == FieldRule.Repeated)
             {


### PR DESCRIPTION
We already skip serializing classes that are null inside the Serialize() method, this also skips when structs are their default value.

More details in https://app.asana.com/0/1132883489782263/1207448248246156