### PR TITLE
Fix ProtoBuf conformance

### DIFF
--- a/CodeGenerator/ProtoParser.cs
+++ b/CodeGenerator/ProtoParser.cs
@@ -221,6 +221,8 @@ namespace SilentOrbit.ProtocolBuffers
             f.ID = int.Parse(tr.ReadNext());
             if (19000 <= f.ID && f.ID <= 19999)
                 throw new ProtoFormatException("Can't use reserved field ID 19000-19999", tr);
+            if (f.ID == 0)
+                throw new ProtoFormatException("Can't use reserved field ID 0", tr);
             if (f.ID > (1 << 29) - 1)
                 throw new ProtoFormatException("Maximum field id is 2^29 - 1", tr);
 


### PR DESCRIPTION
Fields with an ID of 0 are not valid according to the official spec (https://protobuf.dev/programming-guides/proto2/ `You must give each field in your message definition a number between 1 and 536,870,911`). This should be a trivial change and is the only thing required for full proto2 conformance.