### PR TITLE
Allow invalid field (0) to be used as a guaranteed way to terminate the stream being read by the proto

### DIFF
--- a/CodeGenerator/CodeGenerator/MessageSerializer.cs
+++ b/CodeGenerator/CodeGenerator/MessageSerializer.cs
@@ -232,7 +232,11 @@ namespace SilentOrbit.ProtocolBuffers
                 }
 
                 cw.WriteLine("int keyByte = stream.ReadByte();");
-                cw.WriteLine("if (keyByte == -1 || keyByte == 0)");
+
+                if (method == "Deserialize")
+                    cw.WriteLine("if (keyByte == -1 || keyByte == 0)");
+                else
+                    cw.WriteLine("if (keyByte == -1)");
                 if (method == "Deserialize")
                     cw.WriteIndent("break;");
                 else

--- a/CodeGenerator/CodeGenerator/MessageSerializer.cs
+++ b/CodeGenerator/CodeGenerator/MessageSerializer.cs
@@ -232,7 +232,7 @@ namespace SilentOrbit.ProtocolBuffers
                 }
 
                 cw.WriteLine("int keyByte = stream.ReadByte();");
-                cw.WriteLine("if (keyByte == -1)");
+                cw.WriteLine("if (keyByte == -1 || keyByte == 0)");
                 if (method == "Deserialize")
                     cw.WriteIndent("break;");
                 else


### PR DESCRIPTION
Likely means dd89120 shouldn't be re-introduced.